### PR TITLE
Migrate drud/ddev#2258 BASH_ENV for COMPOSER_BIN fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -342,6 +342,7 @@ ENV NGINX_DOCROOT $WEBSERVER_DOCROOT
 ENV TERMINUS_CACHE_DIR=/mnt/ddev-global-cache/terminus/cache
 ENV CAROOT /mnt/ddev-global-cache/mkcert
 ENV DRUSH_LAUNCHER_FALLBACK=/usr/local/bin/drush8
+ENV BASH_ENV /etc/bash.nointeractive.bashrc
 
 ENV DDEV_LIVE_CONFIG_FILE_PATH /mnt/ddev-global-cache/ddev-live/cli-config.json
 ENV DDEV_LIVE_NO_VERSION_PROMPT true

--- a/Dockerfile
+++ b/Dockerfile
@@ -342,7 +342,7 @@ ENV NGINX_DOCROOT $WEBSERVER_DOCROOT
 ENV TERMINUS_CACHE_DIR=/mnt/ddev-global-cache/terminus/cache
 ENV CAROOT /mnt/ddev-global-cache/mkcert
 ENV DRUSH_LAUNCHER_FALLBACK=/usr/local/bin/drush8
-ENV BASH_ENV /etc/bash.nointeractive.bashrc
+ENV BASH_ENV /etc/bash.noninteractive.bashrc
 
 ENV DDEV_LIVE_CONFIG_FILE_PATH /mnt/ddev-global-cache/ddev-live/cli-config.json
 ENV DDEV_LIVE_NO_VERSION_PROMPT true

--- a/ddev-webserver-dev-files/etc/bash.noninteractive.bashrc
+++ b/ddev-webserver-dev-files/etc/bash.noninteractive.bashrc
@@ -1,0 +1,2 @@
+# This file is loaded in non-interactive bash shells through $BASH_ENV
+source /etc/bashrc/*.bashrc

--- a/ddev-webserver-dev-files/etc/bashrc/composer-bin-dir-in-path.bashrc
+++ b/ddev-webserver-dev-files/etc/bashrc/composer-bin-dir-in-path.bashrc
@@ -1,0 +1,9 @@
+# Extends PATH to include the composer bin directory.
+
+# set COMPOSER_BIN_DIR to $WEBSERVER_DOCROOT/vendor/bin if unset
+if [[ ! -v $COMPOSER_BIN_DIR ]]; then
+    export COMPOSER_BIN_DIR="$WEBSERVER_DOCROOT/vendor/bin"
+fi
+
+# add composer bin dir to PATH
+export PATH="$PATH:$COMPOSER_BIN_DIR"

--- a/ddev-webserver-dev-files/etc/bashrc/composer-bin-dir-in-path.bashrc
+++ b/ddev-webserver-dev-files/etc/bashrc/composer-bin-dir-in-path.bashrc
@@ -1,9 +1,2 @@
-# Extends PATH to include the composer bin directory.
-
-# set COMPOSER_BIN_DIR to $WEBSERVER_DOCROOT/vendor/bin if unset
-if [[ ! -v $COMPOSER_BIN_DIR ]]; then
-    export COMPOSER_BIN_DIR="$WEBSERVER_DOCROOT/vendor/bin"
-fi
-
-# add composer bin dir to PATH
-export PATH="$PATH:$COMPOSER_BIN_DIR"
+# add composer's vendor/bin dir to PATH
+export PATH="$PATH:/var/www/html/vendor/bin"

--- a/ddev-webserver-dev-files/etc/skel/.bashrc
+++ b/ddev-webserver-dev-files/etc/skel/.bashrc
@@ -1,0 +1,1 @@
+source /etc/bashrc/*.bashrc

--- a/tests/ddev-webserver-dev/general.bats
+++ b/tests/ddev-webserver-dev/general.bats
@@ -6,3 +6,7 @@
        docker exec $CONTAINER_NAME bash -c "command -v $item >/dev/null"
     done
 }
+
+@test "Verify /var/www/html/vendor/bin is in PATH on ddev/docker exec" {
+    docker exec $CONTAINER_NAME bash -c 'echo $PATH | grep /var/www/html/vendor/bin'
+}


### PR DESCRIPTION
drud/ddev#2258 (drud/ddev@3e8b1c976c660317b796893ee04ba2de758021fa) added BASH_ENV into the container to add /var/www/html/vendor/bin into the PATH for `ddev exec`. This migrates the ddev-webserver part of that patch.