### PR TITLE
Add release build to push docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,4 @@
 version: 2
-jobs:
-  build_and_test:
-    machine:
-      image: ubuntu-1604:201903-01
-
-    steps:
-      - checkout
-      - run: make
-      - run: make test
 
 workflows:
   version: 2
@@ -24,3 +15,35 @@ workflows:
             - master
     jobs:
     - build_and_test
+
+  release:
+    jobs:
+    - release_build:
+        context: ddev-images
+        filters:
+          tags:
+            only:
+            - "/.*/"
+          branches:
+            ignore: /.*/
+
+
+jobs:
+  build_and_test:
+    machine:
+      image: ubuntu-1604:201903-01
+
+    steps:
+      - checkout
+      - run: make
+      - run: make test
+
+  release_build:
+    machine:
+      image: ubuntu-1604:201903-01
+    steps:
+    - checkout
+    - run: make test
+    - run: echo $DOCKERHUB_TOKEN | docker login -u $DOCKERHUB_USERNAME --password-stdin
+    - run: make push
+    - run: docker logout

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ build: images
 images: $(DEFAULT_IMAGES)
 
 push: images
-	for item in $(DEFAULT_IMAGES); do docker push $(DOCKER_ORG)/$$item:$(VERSION); echo "pushed $(DOCKER_ORG)/$item"; done
+	for item in $(DEFAULT_IMAGES); do docker push $(DOCKER_ORG)/$$item:$(VERSION); echo "pushed $(DOCKER_ORG)/$$item"; done
 
 ddev-php-prod ddev-php-base:
 	DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker build --label com.ddev.buildhost=${shell hostname} --target=$@  -t $(DOCKER_ORG)/$@:$(VERSION) $(DOCKER_ARGS) .


### PR DESCRIPTION
This adds the capability of a release build pushing the docker images up when a release is created.