### PR TITLE
Use CIRCLE_TAG to specify tag instead of deriving from git tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,5 +45,5 @@ jobs:
     - checkout
     - run: make test
     - run: echo $DOCKERHUB_TOKEN | docker login -u $DOCKERHUB_USERNAME --password-stdin
-    - run: make push
+    - run: make push VERSION=${CIRCLE_TAG}
     - run: docker logout


### PR DESCRIPTION
More than one tag can refer to one sha, causing confusion.