### PR TITLE
Add arm64 Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,26 +36,26 @@ jobs:
     steps:
       - checkout
       - run:
-        command: |
-          sudo apt-get install docker-ce-cli binfmt-support qemu-user-static
+          command: |
+            sudo apt-get install docker-ce-cli binfmt-support qemu-user-static
 
-          BUILDX_BINARY_URL="https://github.com/docker/buildx/releases/download/v0.4.1/buildx-v0.4.1.linux-amd64"
+            BUILDX_BINARY_URL="https://github.com/docker/buildx/releases/download/v0.4.1/buildx-v0.4.1.linux-amd64"
 
-          curl --output docker-buildx \
-            --silent --show-error --location --fail --retry 3 \
-            "$BUILDX_BINARY_URL"
+            curl --output docker-buildx \
+              --silent --show-error --location --fail --retry 3 \
+              "$BUILDX_BINARY_URL"
 
-          mkdir -p ~/.docker/cli-plugins
-          mv docker-buildx ~/.docker/cli-plugins
-          chmod a+x ~/.docker/cli-plugins/docker-buildx
+            mkdir -p ~/.docker/cli-plugins
+            mv docker-buildx ~/.docker/cli-plugins
+            chmod a+x ~/.docker/cli-plugins/docker-buildx
 
-          # We need this to get arm64 qemu to work https://github.com/docker/buildx/issues/138#issuecomment-569240559
-          docker run --rm --privileged docker/binfmt:66f9012c56a8316f9244ffd7622d7c21c1f6f28d
+            # We need this to get arm64 qemu to work https://github.com/docker/buildx/issues/138#issuecomment-569240559
+            docker run --rm --privileged docker/binfmt:66f9012c56a8316f9244ffd7622d7c21c1f6f28d
 
-          docker buildx create --name ddev-builder-multi
-          docker buildx use ddev-builder-multi
-          docker buildx inspect --bootstrap
-        name: Prepare docker buildx for multi-arch builds
+            docker buildx create --name ddev-builder-multi
+            docker buildx use ddev-builder-multi
+            docker buildx inspect --bootstrap
+          name: Prepare docker buildx for multi-arch builds
       - run: make
       - run: make test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,16 +31,37 @@ workflows:
 jobs:
   build_and_test:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-1604:202007-01
 
     steps:
       - checkout
+      - run:
+        command: |
+          sudo apt-get install docker-ce-cli binfmt-support qemu-user-static
+
+          BUILDX_BINARY_URL="https://github.com/docker/buildx/releases/download/v0.4.1/buildx-v0.4.1.linux-amd64"
+
+          curl --output docker-buildx \
+            --silent --show-error --location --fail --retry 3 \
+            "$BUILDX_BINARY_URL"
+
+          mkdir -p ~/.docker/cli-plugins
+          mv docker-buildx ~/.docker/cli-plugins
+          chmod a+x ~/.docker/cli-plugins/docker-buildx
+
+          # We need this to get arm64 qemu to work https://github.com/docker/buildx/issues/138#issuecomment-569240559
+          docker run --rm --privileged docker/binfmt:66f9012c56a8316f9244ffd7622d7c21c1f6f28d
+
+          docker buildx create --name ddev-builder-multi
+          docker buildx use ddev-builder-multi
+          docker buildx inspect --bootstrap
+        name: Prepare docker buildx for multi-arch builds
       - run: make
       - run: make test
 
   release_build:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-1604:202007-01
     steps:
     - checkout
     - run: make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,12 +57,14 @@ RUN apt-get -qq install --no-install-recommends --no-install-suggests -y \
     sqlite3 \
     yarn
 
-# PHP 5.6 is not available on linux/arm64 so we skip that version
+# PHP 5.6 is not available on linux/arm64 so we skip that version.
+# Also, the php7.4-apcu-bc package is not available on arm64.
+# Details: https://github.com/oerdnj/deb.sury.org/issues/1449
 SHELL ["/bin/bash", "-c"]
 RUN for v in $PHP_VERSIONS; do \
     [[ $v == "php5.6" && $TARGETPLATFORM == "linux/arm64" ]] && continue; \
     apt-get -qq install --no-install-recommends --no-install-suggests -y $v-apcu $v-bcmath $v-bz2 $v-curl $v-cgi $v-cli $v-common $v-fpm $v-gd $v-intl $v-json $v-ldap $v-mbstring $v-memcached $v-mysql $v-opcache $v-pgsql $v-readline $v-redis $v-soap $v-sqlite3 $v-xdebug $v-xml $v-xmlrpc $v-zip || exit $?; \
-    if [ $v != "php5.6" ]; then \
+    if [[ $TARGETPLATFORM == "linux/amd64" && $v != "php5.6" ]] || [[ $TARGETPLATFORM == "linux/arm64" && $v != "php7.4" ]]; then \
         apt-get -qq install --no-install-recommends --no-install-suggests -y $v-apcu-bc || exit $?; \
     fi \
 done

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,9 @@ RUN apt-get -qq install --no-install-recommends --no-install-suggests -y \
     sqlite3 \
     yarn
 
+# PHP 5.6 is not available on linux/arm64 so we skip that version there
 RUN for v in $PHP_VERSIONS; do \
+    if [ $v == "php5.6" && $TARGETPLATFORM == "linux/arm64" ]; then continue; fi \
     apt-get -qq install --no-install-recommends --no-install-suggests -y $v-apcu $v-bcmath $v-bz2 $v-curl $v-cgi $v-cli $v-common $v-fpm $v-gd $v-intl $v-json $v-ldap $v-mbstring $v-memcached $v-mysql $v-opcache $v-pgsql $v-readline $v-redis $v-soap $v-sqlite3 $v-xdebug $v-xml $v-xmlrpc $v-zip || exit $?; \
     if [ $v != "php5.6" ]; then \
         apt-get -qq install --no-install-recommends --no-install-suggests -y $v-apcu-bc || exit $?; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,10 @@ ENV DRUSH_LAUNCHER_FALLBACK=/usr/local/bin/drush8
 # composer normally screams about running as root, we don't need that.
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_PROCESS_TIMEOUT 2000
+# TARGETPLATFORM is Docker buildx's target platform (e.g. linux/arm64), while 
+# BUILDPLATFORM is the platform of the build host (e.g. linux/amd64)
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
 
 RUN wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg && \
     echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && apt-get update
@@ -53,9 +57,10 @@ RUN apt-get -qq install --no-install-recommends --no-install-suggests -y \
     sqlite3 \
     yarn
 
-# PHP 5.6 is not available on linux/arm64 so we skip that version there
+# PHP 5.6 is not available on linux/arm64 so we skip that version
+SHELL ["/bin/bash", "-c"]
 RUN for v in $PHP_VERSIONS; do \
-    if [ $v == "php5.6" && $TARGETPLATFORM == "linux/arm64" ]; then continue; fi \
+    [[ $v == "php5.6" && $TARGETPLATFORM == "linux/arm64" ]] && continue; \
     apt-get -qq install --no-install-recommends --no-install-suggests -y $v-apcu $v-bcmath $v-bz2 $v-curl $v-cgi $v-cli $v-common $v-fpm $v-gd $v-intl $v-json $v-ldap $v-mbstring $v-memcached $v-mysql $v-opcache $v-pgsql $v-readline $v-redis $v-soap $v-sqlite3 $v-xdebug $v-xml $v-xmlrpc $v-zip || exit $?; \
     if [ $v != "php5.6" ]; then \
         apt-get -qq install --no-install-recommends --no-install-suggests -y $v-apcu-bc || exit $?; \
@@ -63,6 +68,7 @@ RUN for v in $PHP_VERSIONS; do \
 done
 
 RUN for v in php5.6 php7.0 php7.1; do \
+    [[ $v == "php5.6" && $TARGETPLATFORM == "linux/arm64" ]] && continue; \
     apt-get -qq install --no-install-recommends --no-install-suggests -y $v-mcrypt || exit $?; \
 done
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ### ---------------------------base--------------------------------------
 ### Build the base Debian image that will be used in every other image
-FROM bitnami/minideb:buster as base
+FROM debian:buster-slim as base
 RUN apt-get -qq update
 RUN apt-get -qq install --no-install-recommends --no-install-suggests -y \
     apt-transport-https \

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ DEFAULT_IMAGES = ddev-php-base ddev-php-prod
 VERSION := $(shell git describe --tags --always --dirty)
 BUILDINFO = $(shell echo hash=$$(git rev-parse --short HEAD) Built $$(date) by $${USER} on $$(hostname) $(BUILD_IMAGE) )
 
+# In CI environments, use the plain Docker build progress to not overload the CI logs
+PROGRESS := $(if $(CI),plain,auto)
+
 #
 # This version-strategy uses a manual value to set the version string
 #VERSION := 1.2.3
@@ -36,7 +39,7 @@ push: images
 	for item in $(DEFAULT_IMAGES); do docker push $(DOCKER_ORG)/$$item:$(VERSION); echo "pushed $(DOCKER_ORG)/$$item"; done
 
 ddev-php-prod ddev-php-base: buildinfo
-	DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker buildx build --progress=plain --platform linux/amd64,linux/arm64 --label com.ddev.buildhost=${shell hostname} --target=$@  -t $(DOCKER_ORG)/$@:$(VERSION) $(DOCKER_ARGS) .
+	DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker buildx build --progress=$(PROGRESS) --platform linux/amd64,linux/arm64 --label com.ddev.buildhost=${shell hostname} --target=$@  -t $(DOCKER_ORG)/$@:$(VERSION) $(DOCKER_ARGS) .
 
 test: images
 	for item in $(DEFAULT_IMAGES); do \

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ push: images
 	for item in $(DEFAULT_IMAGES); do docker push $(DOCKER_ORG)/$$item:$(VERSION); echo "pushed $(DOCKER_ORG)/$$item"; done
 
 ddev-php-prod ddev-php-base: buildinfo
-	DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker buildx build --platform linux/amd64,linux/arm64 --label com.ddev.buildhost=${shell hostname} --target=$@  -t $(DOCKER_ORG)/$@:$(VERSION) $(DOCKER_ARGS) .
+	DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker buildx build --progress=plain --platform linux/amd64,linux/arm64 --label com.ddev.buildhost=${shell hostname} --target=$@  -t $(DOCKER_ORG)/$@:$(VERSION) $(DOCKER_ARGS) .
 
 test: images
 	for item in $(DEFAULT_IMAGES); do \

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ push: images
 	for item in $(DEFAULT_IMAGES); do docker push $(DOCKER_ORG)/$$item:$(VERSION); echo "pushed $(DOCKER_ORG)/$$item"; done
 
 ddev-php-prod ddev-php-base: buildinfo
-	DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker buildx build --progress=$(PROGRESS) --platform linux/amd64,linux/arm64 --label com.ddev.buildhost=${shell hostname} --target=$@  -t $(DOCKER_ORG)/$@:$(VERSION) $(DOCKER_ARGS) .
+	DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker buildx build --progress=$(PROGRESS) --load --platform linux/amd64,linux/arm64 --label com.ddev.buildhost=${shell hostname} --target=$@  -t $(DOCKER_ORG)/$@:$(VERSION) $(DOCKER_ARGS) .
 
 test: images
 	for item in $(DEFAULT_IMAGES); do \

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ push: images
 	for item in $(DEFAULT_IMAGES); do docker push $(DOCKER_ORG)/$$item:$(VERSION); echo "pushed $(DOCKER_ORG)/$$item"; done
 
 ddev-php-prod ddev-php-base: buildinfo
-	DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker buildx build --progress=$(PROGRESS) --load --platform linux/amd64,linux/arm64 --label com.ddev.buildhost=${shell hostname} --target=$@  -t $(DOCKER_ORG)/$@:$(VERSION) $(DOCKER_ARGS) .
+	DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker buildx build --progress=$(PROGRESS) --platform linux/amd64,linux/arm64 --label com.ddev.buildhost=${shell hostname} --target=$@  -t $(DOCKER_ORG)/$@:$(VERSION) $(DOCKER_ARGS) .
 
 test: images
 	for item in $(DEFAULT_IMAGES); do \

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ push: images
 	for item in $(DEFAULT_IMAGES); do docker push $(DOCKER_ORG)/$$item:$(VERSION); echo "pushed $(DOCKER_ORG)/$$item"; done
 
 ddev-php-prod ddev-php-base: buildinfo
-	DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker build --label com.ddev.buildhost=${shell hostname} --target=$@  -t $(DOCKER_ORG)/$@:$(VERSION) $(DOCKER_ARGS) .
+	DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker buildx build --platform linux/amd64,linux/arm64 --label com.ddev.buildhost=${shell hostname} --target=$@  -t $(DOCKER_ORG)/$@:$(VERSION) $(DOCKER_ARGS) .
 
 test: images
 	for item in $(DEFAULT_IMAGES); do \


### PR DESCRIPTION
Part of https://github.com/drud/ddev/pull/2454

**How to build**
- You'll need `docker buildx` [as described here](https://www.docker.com/blog/multi-arch-images/). Installation instructions can be found here: https://github.com/docker/buildx/#building.
- Run `make` as usual.