### PR TITLE
php8.0 xdebug has new settings

### DIFF
--- a/ddev-php-files/etc/php/8.0/mods-available/xdebug.ini
+++ b/ddev-php-files/etc/php/8.0/mods-available/xdebug.ini
@@ -1,6 +1,3 @@
 zend_extension=xdebug.so
-xdebug.remote_enable=1
 xdebug.remote_host=host.docker.internal
-xdebug.remote_autostart=1
-xdebug.remote_port=9000
-xdebug.max_nesting_level=512
+xdebug.mode=debug

--- a/ddev-php-files/etc/php/8.0/mods-available/xdebug.ini
+++ b/ddev-php-files/etc/php/8.0/mods-available/xdebug.ini
@@ -1,3 +1,5 @@
 zend_extension=xdebug.so
-xdebug.remote_host=host.docker.internal
+xdebug.client_host=host.docker.internal
+xdebug.client_port=9000
 xdebug.mode=debug
+xdebug.start_with_request=yes


### PR DESCRIPTION
Per https://3.xdebug.org/docs/upgrade_guide#xdebug.remote_enable xdebug v3 has new settings (and the old ones don't work).

Provide the new ones for php8. I think we'll be getting them for other php7 later.