### PR TITLE
Use php-version-specific packages for imagick and uploadprogress, for drud/ddev#2934

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,6 @@ RUN apt-get -qq install --no-install-recommends --no-install-suggests -y \
     mariadb-client \
     msmtp \
     nodejs \
-    php-imagick \
     php-uploadprogress \
     sqlite3
 
@@ -60,21 +59,21 @@ RUN npm config set unsafe-perm true && npm install --global gulp-cli yarn
 
 # The number of permutations of php packages available on each architecture because
 # too much to handle, so has been codified here instead of in obscure logic
-ENV php56_amd64="apcu bcmath bz2 curl cli common fpm gd intl json ldap mbstring mcrypt memcached mysql opcache pgsql readline redis soap sqlite3 xdebug xml xmlrpc zip"
-ENV php56_arm64="apcu bcmath bz2 curl cli common fpm gd intl json ldap mbstring mcrypt mysql opcache pgsql readline soap sqlite3 xdebug xml xmlrpc zip"
-ENV php70_amd64="apcu apcu-bc bcmath bz2 curl cli common fpm gd intl json ldap mbstring mcrypt memcached mysql opcache pgsql readline redis soap sqlite3 xdebug xml xmlrpc zip"
+ENV php56_amd64="apcu bcmath bz2 curl cli common fpm gd imagick intl json ldap mbstring mcrypt memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xml xmlrpc zip"
+ENV php56_arm64="apcu bcmath bz2 curl cli common fpm gd imagick intl json ldap mbstring mcrypt mysql opcache pgsql readline soap sqlite3 uploadprogress xdebug xml xmlrpc zip"
+ENV php70_amd64="apcu apcu-bc bcmath bz2 curl cli common fpm gd imagick intl json ldap mbstring mcrypt memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xml xmlrpc zip"
 ENV php70_arm64=$php70_amd64
 ENV php71_amd64=$php70_amd64
 ENV php71_arm64=$php70_arm64
-ENV php72_amd64="apcu apcu-bc bcmath bz2 curl cli common fpm gd intl json ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 xdebug xml xmlrpc zip"
+ENV php72_amd64="apcu apcu-bc bcmath bz2 curl cli common fpm gd imagick intl json ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xml xmlrpc zip"
 ENV php72_arm64=$php72_amd64
 ENV php73_amd64=$php72_amd64
 ENV php73_arm64=$php72_arm64
-ENV php74_amd64="apcu apcu-bc bcmath bz2 curl cli common fpm gd intl json ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 xdebug xml xmlrpc zip"
+ENV php74_amd64="apcu apcu-bc bcmath bz2 curl cli common fpm gd imagick intl json ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xml xmlrpc zip"
 ENV php74_arm64=$php74_amd64
 
 # As of php8.0 json is now part of core package and xmlrpc has been removed from PECL
-ENV php80_amd64="apcu bcmath bz2 curl cli common fpm gd intl ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 xdebug xml zip"
+ENV php80_amd64="apcu bcmath bz2 curl cli common fpm gd imagick intl ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 xdebug xml zip"
 ENV php80_arm64=$php80_amd64
 
 RUN for v in $PHP_VERSIONS; do \


### PR DESCRIPTION
## Issue ID(s): drud/ddev#2934

Upstream usage seems to have changed, and php-imagick didn't make it into ddev v1.17.0 for php7.*

Switch the usage to installing each item.

## Tests:
<!-- Tests introduced by this PR, manual steps to validate the fix, or an explanation for why no tests are needed. -->

## Release/Deployment notes:
<!-- Are there ramifications to other code? Does anything have to be done on deployment? -->
