### PR TITLE
Add php8.0-xmlrpc to list for drud/ddev#2934

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ ENV php74_amd64="apcu apcu-bc bcmath bz2 curl cli common fpm gd imagick intl jso
 ENV php74_arm64=$php74_amd64
 
 # As of php8.0 json is now part of core package and xmlrpc has been removed from PECL
-ENV php80_amd64="apcu bcmath bz2 curl cli common fpm gd imagick intl ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 xdebug xml zip"
+ENV php80_amd64="apcu bcmath bz2 curl cli common fpm gd imagick intl ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 xdebug xml xmlrpc zip"
 ENV php80_arm64=$php80_amd64
 
 RUN for v in $PHP_VERSIONS; do \


### PR DESCRIPTION
## Issue ID(s): drud/ddev#2934 added tests that detected missing php8.0-xmlrpc

