### PR TITLE
Change base image to debian:bullseye-slim, add tree, add php8.0-uploadprogress

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
       - CI: "true"
       - BUILDKIT_PROGRESS: plain
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202104-01
     steps:
     - checkout
     - run: ./.circleci/linux_circle_vm_setup.sh

--- a/.circleci/linux_circle_vm_setup.sh
+++ b/.circleci/linux_circle_vm_setup.sh
@@ -15,5 +15,9 @@ mkdir -p ~/.docker/cli-plugins
 mv docker-buildx ~/.docker/cli-plugins
 chmod a+x ~/.docker/cli-plugins/docker-buildx
 
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+
 if ! docker buildx inspect ddev-builder-multi --bootstrap >/dev/null; then docker buildx create --name ddev-builder-multi; fi
 docker buildx use ddev-builder-multi
+docker buildx inspect --bootstrap
+

--- a/.circleci/linux_circle_vm_setup.sh
+++ b/.circleci/linux_circle_vm_setup.sh
@@ -15,7 +15,5 @@ mkdir -p ~/.docker/cli-plugins
 mv docker-buildx ~/.docker/cli-plugins
 chmod a+x ~/.docker/cli-plugins/docker-buildx
 
-# We need this to get arm64 qemu to work https://github.com/docker/buildx/issues/138#issuecomment-569240559
-docker run --rm --privileged docker/binfmt:66f9012c56a8316f9244ffd7622d7c21c1f6f28d
 if ! docker buildx inspect ddev-builder-multi --bootstrap >/dev/null; then docker buildx create --name ddev-builder-multi; fi
 docker buildx use ddev-builder-multi

--- a/.circleci/linux_circle_vm_setup.sh
+++ b/.circleci/linux_circle_vm_setup.sh
@@ -21,3 +21,5 @@ if ! docker buildx inspect ddev-builder-multi --bootstrap >/dev/null; then docke
 docker buildx use ddev-builder-multi
 docker buildx inspect --bootstrap
 
+which dpkg-split
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,13 @@
 ### Build the base Debian image that will be used in every other image
 FROM debian:bullseye-slim as base
 
-RUN ls -l $(which dpkg-split)
-RUN if [ ! -f /usr/sbin/dpkg-split ]; then ln -sf /usr/bin/dpkg-split /usr/sbin/dpkg-split; fi
-RUN ls -l /usr/sbin/dpkg-split
+RUN ls -l $(which dpkg-split) && ls -l $(which dpkg-deb)
+RUN for item in dpkg-split dpkg-deb; do \
+  if [ ! -f /usr/sbin/$item ]; then \
+    ln -sf /usr/bin/$item /usr/sbin/$item; \
+  fi; \
+done
+RUN ls -l /usr/sbin/dpkg-split /usr/sbin/dpkg-deb
 
 RUN apt-get -qq update
 RUN apt-get -qq install --no-install-recommends --no-install-suggests -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,13 @@ RUN for item in dpkg-split dpkg-deb; do \
     ln -sf /usr/bin/$item /usr/sbin/$item; \
   fi; \
 done
-RUN   if [ ! -f /usr/sbin/tar ]; then ln -s /bin/tar /usr/sbin/tar; fi
-RUN ls -l /usr/sbin/dpkg-split /usr/sbin/dpkg-deb /usr/sbin/tar
+RUN for item in tar rm; do \
+  if [ ! -f /usr/sbin/$item ]; then \
+    ln -sf /bin/$item /usr/sbin/$item; \
+  fi; \
+done
+
+RUN ls -l /usr/sbin/dpkg-split /usr/sbin/dpkg-deb /usr/sbin/tar /usr/sbin/rm
 
 RUN apt-get -qq update
 RUN apt-get -qq install --no-install-recommends --no-install-suggests -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get -qq install --no-install-recommends --no-install-suggests -y \
     less \
     lsb-release \
     procps \
+    tree \
     vim \
     wget
 #END base

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN for item in dpkg-split dpkg-deb; do \
     ln -sf /usr/bin/$item /usr/sbin/$item; \
   fi; \
 done
-RUN ls -l /usr/sbin/dpkg-split /usr/sbin/dpkg-deb
+RUN   if [ ! -f /usr/sbin/tar ]; then ln -s /bin/tar /usr/sbin/tar; fi
+RUN ls -l /usr/sbin/dpkg-split /usr/sbin/dpkg-deb /usr/sbin/tar
 
 RUN apt-get -qq update
 RUN apt-get -qq install --no-install-recommends --no-install-suggests -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ### ---------------------------base--------------------------------------
 ### Build the base Debian image that will be used in every other image
-FROM debian:buster-slim as base
+FROM debian:bullseye-slim as base
 RUN apt-get -qq update
 RUN apt-get -qq install --no-install-recommends --no-install-suggests -y \
     apt-transport-https \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 ### ---------------------------base--------------------------------------
 ### Build the base Debian image that will be used in every other image
 FROM debian:bullseye-slim as base
+
+RUN ls -l $(which dpkg-split)
+RUN if [ ! -f /usr/sbin/dpkg-split ]; then ln -sf /usr/bin/dpkg-split /usr/sbin/dpkg-split; fi
+RUN ls -l /usr/sbin/dpkg-split
+
 RUN apt-get -qq update
 RUN apt-get -qq install --no-install-recommends --no-install-suggests -y \
     apt-transport-https \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,6 @@ RUN apt-get -qq install --no-install-recommends --no-install-suggests -y \
     procps \
     vim \
     wget
-# Without c_rehash TLS fails (at least for curl) on arm/v7
-# See https://github.com/balena-io-library/base-images/issues/562
-RUN c_rehash
 #END base
 
 ### ---------------------------ddev-php-base--------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,7 @@ ENV php74_amd64="apcu apcu-bc bcmath bz2 curl cli common fpm gd imagick intl jso
 ENV php74_arm64=$php74_amd64
 
 # As of php8.0 json is now part of core package and xmlrpc has been removed from PECL
-ENV php80_amd64="apcu bcmath bz2 curl cli common fpm gd imagick intl ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 xdebug xhprof xml xmlrpc zip"
+ENV php80_amd64="apcu bcmath bz2 curl cli common fpm gd imagick intl ldap mbstring memcached mysql opcache pgsql readline redis soap sqlite3 uploadprogress xdebug xhprof xml xmlrpc zip"
 ENV php80_arm64=$php80_amd64
 
 RUN for v in $PHP_VERSIONS; do \


### PR DESCRIPTION
There is a minor note in a Docker release:

> On Apple Silicon in native arm64 containers, older versions of libssl in debian:buster, ubuntu:20.04 and centos:8 will segfault when connected to some TLS servers, for example curl https://dl.yarnpkg.com. The bug is fixed in newer versions of libssl in debian:bullseye, ubuntu:21.04 and fedora:35

And this is causing issues for some people in typo3-land, and could be the cause of crashing platform and acli tools.
