### PR TITLE
Update ubuntu runner and remove special qemu stuff

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,8 +31,8 @@ workflows:
 jobs:
   build_and_test:
     environment:
-      - CI: "true"
-      - BUILDKIT_PROGRESS: "plain"
+      CI: "true"
+      BUILDKIT_PROGRESS: "plain"
     machine:
       image: ubuntu-2004:202107-02
 

--- a/.circleci/linux_circle_vm_setup.sh
+++ b/.circleci/linux_circle_vm_setup.sh
@@ -3,10 +3,12 @@
 set -eu -o pipefail
 set -x
 
-# Get recent qemu
+# Get recent qemu to avoid constant qemu crashes on Ubuntu 20.04
+# Incomprehensible discussions of the problem at
+# https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/1928075
 sudo add-apt-repository ppa:jacob/virtualisation
 
-sudo apt-get -qq update && sudo apt-get -qq install -y docker-ce-cli binfmt-support  qemu qemu-user-static
+sudo apt-get -qq update && sudo apt-get -qq install -y docker-ce-cli binfmt-support  qemu qemu-user qemu-user-static
 
 
 # Get recent buildx

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,12 +99,13 @@ RUN for v in $PHP_VERSIONS; do \
     [[ ${pkgs// } != "" ]] && (apt-get -qq install --no-install-recommends --no-install-suggests -y $pkgs || exit $?) \
 done
 RUN phpdismod xhprof
+RUN apt-get -qq autoremove -y
 RUN curl -o /usr/local/bin/composer -sSL https://getcomposer.org/composer-stable.phar && chmod ugo+wx /usr/local/bin/composer
 RUN curl -sSL "https://github.com/drush-ops/drush/releases/download/${DRUSH_VERSION}/drush.phar" -o /usr/local/bin/drush8 && chmod +x /usr/local/bin/drush8
 RUN curl -sSL -o /usr/local/bin/wp-cli -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar && chmod +x /usr/local/bin/wp-cli && ln -sf /usr/local/bin/wp-cli /usr/local/bin/wp
 RUN url="https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${TARGETPLATFORM#linux/}"; wget ${url} -O /usr/bin/yq && chmod +x /usr/bin/yq
 ADD ddev-php-files /
-RUN apt-get -qq clean -y && rm -rf /var/lib/apt/lists/*
+RUN apt-get -qq autoremove && apt-get -qq clean -y && rm -rf /var/lib/apt/lists/*
 RUN	update-alternatives --set php /usr/bin/php${DDEV_PHP_VERSION}
 RUN ln -sf /usr/sbin/php-fpm${DDEV_PHP_VERSION} /usr/sbin/php-fpm
 RUN mkdir -p /run/php && chown -R www-data:www-data /run


### PR DESCRIPTION
The nightly build has been failing regularly with 
```
Status: Downloaded newer image for multiarch/qemu-user-static:latest
Setting /usr/bin/qemu-alpha-static as binfmt interpreter for alpha
sh: write error: Invalid argument
sh: write error: Invalid argument
Setting /usr/bin/qemu-arm-static as binfmt interpreter for arm
Setting /usr/bin/qemu-armeb-static as binfmt interpreter for armeb
sh: write error: Invalid argument
```

* This was using Ubuntu 16.04 builder - upgrade to 20.04
* Use latest buildx plugin
* Remove the `docker run --rm --privileged multiarch/qemu-user-static --reset -p yes` and see if it was needed anyway.