### PR TITLE
Update nodejs default version to 16.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ SHELL ["/bin/bash", "-c"]
 
 RUN wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg && \
     echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && apt-get update
-RUN curl -sSL --fail https://deb.nodesource.com/setup_14.x | bash -
+RUN curl -sSL --fail https://deb.nodesource.com/setup_16.x | bash -
 
 RUN apt-get -qq update
 RUN apt-get -qq install --no-install-recommends --no-install-suggests -y \


### PR DESCRIPTION
This updates default nodejs version to 16.x

But this can't actually go in until master branch diverges for ddev v1.19.0, so don't pull it.